### PR TITLE
Add prompt type management feature for test generation

### DIFF
--- a/QaseTestCaseGenerator/Commands/QaseCommands.cs
+++ b/QaseTestCaseGenerator/Commands/QaseCommands.cs
@@ -138,7 +138,7 @@ namespace QaseTestCaseGenerator.Commands
         /// <param name="notes">The notes to generate test cases from.</param>
         private static async Task GenerateAndExportTests(string notes)
         {
-            OpenAISettings.Notes = notes;
+            UserSettings.PromptSettings.Notes = notes;
             List<TestCase> testCases = await GenerateTestCasesWithAI();
             if(testCases.Count == 0)
             {

--- a/QaseTestCaseGenerator/Commands/SettingsCommands.cs
+++ b/QaseTestCaseGenerator/Commands/SettingsCommands.cs
@@ -24,6 +24,53 @@ namespace QaseTestCaseGenerator.Commands
         }
 
         /// <summary>
+        /// Selects prompt that will be used in requests to Open AI.
+        /// </summary>
+        /// <returns>An action that changes current selected prompt.</returns>
+        public static Action SelectPrompt()
+        {
+            return () =>
+            {
+                var promptSelected = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("[yellow]Select a prompt to use[/]")
+                        .AddChoices(
+                            "Default",
+                            "Trade",
+                            "AMS",
+                            "AT",
+                            "Return"
+                        )
+                );
+
+                switch (promptSelected)
+                {
+                    case "Default":
+                        OpenAISettings.SetActivePrompt(PromptType.Default);
+                        break;
+
+                    case "Trade":
+                        OpenAISettings.SetActivePrompt(PromptType.Trade);
+                        break;
+
+                    case "AMS":
+                        OpenAISettings.SetActivePrompt(PromptType.AMS);
+                        break;
+
+                    case "AT":
+                        OpenAISettings.SetActivePrompt(PromptType.AT);
+                        break;
+
+                    case "Return":
+                        return;
+                }
+
+                AnsiConsole.MarkupLine("[green]Prompt selected successfully![/]");
+            };
+        }
+
+
+        /// <summary>
         /// Changes the Qase settings.
         /// </summary>
         /// <returns>An action that changes the Qase settings.</returns>
@@ -156,6 +203,7 @@ namespace QaseTestCaseGenerator.Commands
                         , "UserTestCaseDirectory"
                         , "QaseApiToken"
                         , "OpenAIModel"
+                        , "Prompt type"
                         , "Return"));
                 switch (settingsSelected)
                 {
@@ -189,6 +237,7 @@ namespace QaseTestCaseGenerator.Commands
                             if (newValue.ToLower() != "return") UserSettings.QaseApiToken = newValue;
                             break;
                         }
+
                     case "OpenAIModel":
                         {
                             AnsiConsole.MarkupLine($"[yellow]Current OpenAI model: [fuchsia]'{UserSettings.OpenAIModel}'[/][/]");
@@ -215,6 +264,43 @@ namespace QaseTestCaseGenerator.Commands
                                     return;
                             }
                             AnsiConsole.MarkupLine($"[green]OpenAI model set to: {UserSettings.OpenAIModel}[/]");
+                            break;
+                        }
+                        case "Prompt type":
+                        {
+                            AnsiConsole.MarkupLine($"[yellow]Current prompt type: [fuchsia]'{UserSettings.PromptSettings}'[/][/]");
+                            var selectedPrompt = AnsiConsole.Prompt(
+                                new SelectionPrompt<string>()
+                                    .Title("[yellow]Which prompt type do you want to use?[/]")
+                                    .AddChoices(
+                                        "Default",
+                                        "Trade",
+                                        "AMS",
+                                        "AT",
+                                        "Return")
+                            );
+                            switch (selectedPrompt)
+                            {
+                                case "Default":
+                                    UserSettings.PromptSettings = OpenAISettings.OpenAIPrompts[PromptType.Default];
+                                    break;
+
+                                case "Trade":
+                                    UserSettings.PromptSettings = OpenAISettings.OpenAIPrompts[PromptType.Trade];
+                                    break;
+
+                                case "AMS":
+                                    UserSettings.PromptSettings = OpenAISettings.OpenAIPrompts[PromptType.AMS];
+                                    break;
+
+                                case "AT":
+                                    UserSettings.PromptSettings = OpenAISettings.OpenAIPrompts[PromptType.AT];
+                                    break;
+
+                                case "Return":
+                                    return;
+                            }
+                            AnsiConsole.MarkupLine($"[green]Prompt set to: {UserSettings.PromptSettings.Type}[/]");
                             break;
                         }
                     case "Return":

--- a/QaseTestCaseGenerator/Commands/ShowCommands.cs
+++ b/QaseTestCaseGenerator/Commands/ShowCommands.cs
@@ -1,4 +1,5 @@
-﻿using QaseTestCaseGenerator.Settings;
+﻿using QaseTestCaseGenerator.Models;
+using QaseTestCaseGenerator.Settings;
 using QaseTestCaseGenerator.Static;
 using Spectre.Console;
 
@@ -212,12 +213,25 @@ namespace QaseTestCaseGenerator.Commands
             return () =>
             {
                 var promptSelected = AnsiConsole.Prompt(
-                    new SelectionPrompt<string>()
+                    new SelectionPrompt<PromptType>()
                         .Title($"[yellow]Select prompt template you want to view[/]")
                         .AddChoices(OpenAISettings.OpenAIPrompts.Keys));
-                AnsiConsole.Write(new Panel($"[yellow]Selected prompt template: \n[/]{OpenAISettings.OpenAIPrompts[promptSelected]}").Expand());
+                AnsiConsole.Write(new Panel($"[yellow]Selected prompt template: \n[/]{OpenAISettings.OpenAIPrompts[promptSelected].PromptTemplate}").Expand());
             };
         }
+
+        /// <summary>
+        /// Displays the selected prompt.
+        /// </summary>
+        /// <returns>An action that display selected prompt</returns>
+        public static Action ShowCurrentPrompt()
+        {
+            return () =>
+            {
+                AnsiConsole.Write(new Panel($"[yellow]Selected prompt [fuchsia]{UserSettings.PromptSettings.Type}[/]: \n[/]{UserSettings.PromptSettings.Prompt}").Expand());
+            };
+        }
+
 
         /// <summary>
         /// Displays the available user profiles.

--- a/QaseTestCaseGenerator/Models/PromptSettings.cs
+++ b/QaseTestCaseGenerator/Models/PromptSettings.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QaseTestCaseGenerator.Models
+{
+    public class PromptSettings
+    {
+        public string Notes { get; set; } = "";
+        private int MinimalTestCount { get; set; } = 15;
+        public int MaxTokens { get; set; } = 4000;
+        public PromptType Type { get; private set; }
+        public string Prompt => GeneratePrompt();
+        public string PromptTemplate => GeneratePrompt(asTemplate: true);
+        public PromptSettings(PromptType type)
+        {
+            Type = type;
+        }
+
+
+        /// <summary>
+        /// Generates and returns a default prompt for the OpenAI API based on the current notes and minimal test count.
+        /// </summary>
+        /// <param name="asTemplate">Whether to return prompt as a template.</param>
+        /// <returns>A string representing the prompt.</returns>
+        private string GenerateDefaultPrompt(bool asTemplate = false)
+        {
+            string minimalTestCount = asTemplate ? "[fuchsia]<Minimal Test Count>[/]" : MinimalTestCount.ToString();
+            string notes = asTemplate ? "[fuchsia]<Notes>[/]" : Notes;
+            return $"Extract structured test cases from the following unstructured notes." +
+                    $" Generate **at least {minimalTestCount} test cases** (do not merge them!). If the data allows, generate even more." +
+                    $" Each test case must include the following fields:\n" +
+                    $"- **Title**: An unique test case title\n" +
+                    $"- **Description**: A short summary of the test case\n" +
+                    $"- **Preconditions**: If applicable, otherwise state 'None'\n" +
+                    $"- **Steps**: Each step must include an action and an expected result (minimum 2 steps, but use more if needed)\n" +
+                    $"### Notes:\n" +
+                    $"{notes}\n\n" +
+                    $"### Format:\n" +
+                    $"Title: <Test Case Title>\n" +
+                    $"Description: <Short summary of the test case>\n" +
+                    $"Preconditions: <If applicable, otherwise state 'None'>\n" +
+                    $"Steps:\n" +
+                    $"1. <Step 1>\n" +
+                    $"   Expected: <Expected result>\n" +
+                    $"2. <Step 2>\n" +
+                    $"   Expected: <Expected result>\n" +
+                    $"3. <Step 3> \n" +
+                    $"   Expected: <Expected result>\n" +
+                    $"...\n\n" +
+                    $"**Rules**:\n" +
+                    $"- **DO NOT** merge test cases.\n" +
+                    $"- **Ensure at least {minimalTestCount} test cases** (or more if possible).\n" +
+                    $"- **Every test case must have at least 2 steps**, but some will require more.\n" +
+                    $"- **Extract as many test cases as possible** based on the given notes.\n" +
+                    $"- **Follow format exactly**.";
+        }
+
+        private static string GenerateTradePrompt(bool asTemplate = false)
+        {
+            return "";
+        }
+
+        private static string GenerateAMSPrompt(bool asTemplate = false)
+        {
+            return "";
+        }
+
+        private static string GenerateATPrompt(bool asTemplate = false)
+        {
+            return "";
+        }
+
+
+
+
+        /// <summary>
+        /// Generates a prompt for the OpenAI API based on the current notes and minimal test count.
+        /// </summary>
+        /// <param name="asTemplate"></param>
+        /// <returns>Returns string that has current properties injected into selected template</returns>
+        private string GeneratePrompt(bool asTemplate = false)
+        {
+            string minimalTestCount = MinimalTestCount.ToString();
+            string notes = Notes;
+
+            switch (Type)
+            {
+                case PromptType.Default:
+                    return GenerateDefaultPrompt(asTemplate);
+
+                case PromptType.Trade:
+                    return GenerateTradePrompt(asTemplate);
+
+                case PromptType.AMS:
+                    return GenerateAMSPrompt(asTemplate);
+
+                case PromptType.AT:
+                    return GenerateATPrompt(asTemplate);
+
+                default:
+                    return "Invalid prompt type.";
+            }
+        }
+    }
+}

--- a/QaseTestCaseGenerator/Models/PromptType.cs
+++ b/QaseTestCaseGenerator/Models/PromptType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QaseTestCaseGenerator.Models
+{
+    /// <summary>
+    /// Possible prompt types for the OpenAI API.
+    /// </summary>
+    public enum PromptType
+    {
+        Default,
+        Trade,
+        AMS,
+        AT
+    }
+}

--- a/QaseTestCaseGenerator/Models/UserSettingsDto.cs
+++ b/QaseTestCaseGenerator/Models/UserSettingsDto.cs
@@ -11,6 +11,7 @@ namespace QaseTestCaseGenerator.Models
         public string? JsessionIdCookie { get; set; }
         public string? OpenAIApiKey { get; set; }
         public string? QaseApiToken { get; set; }
+        public PromptSettings? PromptSettings { get; set; }
         #endregion
 
         #region Public Methods
@@ -27,7 +28,8 @@ namespace QaseTestCaseGenerator.Models
                 OpenAIApiKey = UserSettings.OpenAIApiKey,
                 UserTestCaseDirectory = UserSettings.UserTestCaseDirectory,
                 OpenAIModel = UserSettings.OpenAIModel,
-                QaseApiToken = UserSettings.QaseApiToken
+                QaseApiToken = UserSettings.QaseApiToken,
+                PromptSettings = UserSettings.PromptSettings
             };
         }
 
@@ -42,6 +44,7 @@ namespace QaseTestCaseGenerator.Models
             UserSettings.UserTestCaseDirectory = UserTestCaseDirectory;
             UserSettings.OpenAIModel = OpenAIModel;
             UserSettings.QaseApiToken = QaseApiToken;
+            UserSettings.PromptSettings = PromptSettings ?? OpenAISettings.OpenAIPrompts[PromptType.Default];
         }
         #endregion
     }

--- a/QaseTestCaseGenerator/Settings/AppSettings.cs
+++ b/QaseTestCaseGenerator/Settings/AppSettings.cs
@@ -291,6 +291,7 @@ namespace QaseTestCaseGenerator.Settings
             StaticObjects.commands.Add(new Command { CommandName = "save_user_profile", CommandMethod = args => Task.Run(() => SettingsCommands.SaveUserProfile().Invoke()), Description = "Saves current settings into a password protected profile" });
             StaticObjects.commands.Add(new Command { CommandName = "load_user_profile", CommandMethod = args => Task.Run(() => SettingsCommands.LoadUserProfile().Invoke()), Description = "Loads and applies settings from a profile" });
             StaticObjects.commands.Add(new Command { CommandName = "change_qase_settings", CommandMethod = args => Task.Run(() => SettingsCommands.ChangeQaseSettings().Invoke()), Description = "Change Qase settings" });
+            StaticObjects.commands.Add(new Command { CommandName = "change_prompt", CommandMethod = args => Task.Run(() => SettingsCommands.SelectPrompt().Invoke()), Description = "Change current selected prompt" });
             StaticObjects.commands.Add(new Command { CommandName = "change_user_settings", CommandMethod = args => Task.Run(() => SettingsCommands.ChangeUserSettings().Invoke()), Description = "Change user settings, app wont function properly if settings are not set" });
             StaticObjects.commands.Add(new Command { CommandName = "delete_user_profile", CommandMethod = args => Task.Run(() => SettingsCommands.DeleteUserProfile().Invoke()), Description = "Deletes existing profile" });
             StaticObjects.commands.Add(new Command { CommandName = "exit", CommandMethod = args => Task.Run(() => SettingsCommands.Exit().Invoke()), Description = "Closes the app" });
@@ -306,6 +307,7 @@ namespace QaseTestCaseGenerator.Settings
             StaticObjects.commands.Add(new Command { CommandName = "show_all_command_details", CommandMethod = args => Task.Run(() => ShowCommands.ShowAllCommands().Invoke()), Description = "Show all command details" });
             StaticObjects.commands.Add(new Command { CommandName = "show_user_profiles", CommandMethod = args => Task.Run(() => ShowCommands.ShowUserProfiles().Invoke()), Description = "Shows user profiles" });
             StaticObjects.commands.Add(new Command { CommandName = "show_openai_prompt_templates", CommandMethod = args => Task.Run(() => ShowCommands.ShowPromptTemplates().Invoke()), Description = "Shows possible OpenAI prompt templates" });
+            StaticObjects.commands.Add(new Command { CommandName = "show_selected_prompt", CommandMethod = args => Task.Run(() => ShowCommands.ShowCurrentPrompt().Invoke()), Description = "Show currently selected prompt" });
 
         }
         #endregion

--- a/QaseTestCaseGenerator/Settings/OpenAISettings.cs
+++ b/QaseTestCaseGenerator/Settings/OpenAISettings.cs
@@ -1,4 +1,6 @@
-﻿namespace QaseTestCaseGenerator.Settings
+﻿using QaseTestCaseGenerator.Models;
+
+namespace QaseTestCaseGenerator.Settings
 {
     public class OpenAISettings
     {
@@ -7,25 +9,28 @@
         public const string BalanceURL = "https://api.openai.com/v1/dashboard/billing/credit_grants";
         #endregion
 
-        #region Fields
-        private static int _maxTokens = 4000;
-        private static string _notes = "";
-        private static string _prompt = GenerateDefaultPrompt();
-        private static int _minimalTestCount = 15;
-        #endregion
-
         #region Properties
-        public static string Notes { get { return _notes; } set { _notes = value; _prompt = GenerateDefaultPrompt(); } }
-        public static Dictionary<string, string> OpenAIPrompts = new Dictionary<string, string>
+        public static Dictionary<PromptType, PromptSettings> OpenAIPrompts { get; } = new Dictionary<PromptType, PromptSettings>
         {
-            {"Default Prompt", GenerateDefaultPrompt(true)},
-            {"Trade Prompt", GenerateTradePrompt(true) },
-            {"AMS Prompt", GenerateAMSPrompt(true) },
-            {"AT Prompt", GenerateATPrompt(true) }
+            { PromptType.Default, new PromptSettings(PromptType.Default) },
+            { PromptType.Trade, new PromptSettings(PromptType.Trade) },
+            { PromptType.AMS, new PromptSettings(PromptType.AMS) },
+            { PromptType.AT, new PromptSettings(PromptType.AT) }
         };
         #endregion
 
         #region Public Methods
+        /// <summary>
+        /// Sets the active prompt type.
+        /// </summary>
+        public static void SetActivePrompt(PromptType promptType)
+        {
+            if (OpenAIPrompts.ContainsKey(promptType))
+            {
+                UserSettings.PromptSettings = OpenAIPrompts[promptType];
+            }
+        }
+
         /// <summary>
         /// Constructs and returns the request body for the OpenAI API.
         /// </summary>
@@ -38,67 +43,12 @@
                 messages = new[]
                 {
                     new { role = "system", content = "You are an AI that extracts structured test cases from unstructured notes." },
-                    new { role = "user", content = _prompt }
+                    new { role = "user", content = UserSettings.PromptSettings.Prompt }
                 },
-                max_tokens = _maxTokens
+                max_tokens = UserSettings.PromptSettings.MaxTokens
             };
         }
 
-        #endregion
-
-        #region Private Methods
-        /// <summary>
-        /// Generates and returns a default prompt for the OpenAI API based on the current notes and minimal test count.
-        /// </summary>
-        /// <param name="asTemplate">Whether to return prompt as a template.</param>
-        /// <returns>A string representing the prompt.</returns>
-        private static string GenerateDefaultPrompt(bool asTemplate = false)
-        {
-            string minimalTestCount = asTemplate ? "[fuchsia]<Minimal Test Count>[/]" : _minimalTestCount.ToString();
-            string notes = asTemplate ? "[fuchsia]<Notes>[/]" : Notes;
-            return $"Extract structured test cases from the following unstructured notes." +
-                    $" Generate **at least {minimalTestCount} test cases** (do not merge them!). If the data allows, generate even more." +
-                    $" Each test case must include the following fields:\n" +
-                    $"- **Title**: An unique test case title\n" +
-                    $"- **Description**: A short summary of the test case\n" +
-                    $"- **Preconditions**: If applicable, otherwise state 'None'\n" +
-                    $"- **Steps**: Each step must include an action and an expected result (minimum 2 steps, but use more if needed)\n" +
-                    $"### Notes:\n" +
-                    $"{notes}\n\n" +
-                    $"### Format:\n" +
-                    $"Title: <Test Case Title>\n" +
-                    $"Description: <Short summary of the test case>\n" +
-                    $"Preconditions: <If applicable, otherwise state 'None'>\n" +
-                    $"Steps:\n" +
-                    $"1. <Step 1>\n" +
-                    $"   Expected: <Expected result>\n" +
-                    $"2. <Step 2>\n" +
-                    $"   Expected: <Expected result>\n" +
-                    $"3. <Step 3> \n" +
-                    $"   Expected: <Expected result>\n" +
-                    $"...\n\n" +
-                    $"**Rules**:\n" +
-                    $"- **DO NOT** merge test cases.\n" +
-                    $"- **Ensure at least {minimalTestCount} test cases** (or more if possible).\n" +
-                    $"- **Every test case must have at least 2 steps**, but some will require more.\n" +
-                    $"- **Extract as many test cases as possible** based on the given notes.\n" +
-                    $"- **Follow format exactly**.";
-        }
-
-        private static string GenerateTradePrompt(bool asTemplate = false)
-        {
-            return "";
-        }
-
-        private static string GenerateAMSPrompt(bool asTemplate = false)
-        {
-            return "";
-        }
-
-        private static string GenerateATPrompt(bool asTemplate = false)
-        {
-            return "";
-        }
         #endregion
     }
 }

--- a/QaseTestCaseGenerator/Settings/UserSettings.cs
+++ b/QaseTestCaseGenerator/Settings/UserSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace QaseTestCaseGenerator.Settings
+﻿using QaseTestCaseGenerator.Models;
+
+namespace QaseTestCaseGenerator.Settings
 {
     public class UserSettings
     {
@@ -11,6 +13,7 @@
         public static string? JsessionIdCookie { get; set; }
         public static string? OpenAIApiKey { get; set; }
         public static string? QaseApiToken { get; set; }
+        public static PromptSettings PromptSettings { get; set; } = new PromptSettings(PromptType.Default);
         public static string UserTestCaseDirectory { get; set; } = "TestCases";
         public static string OpenAIModel { get; set; } = "gpt-3.5-turbo";
         #endregion


### PR DESCRIPTION
This commit introduces a new feature that allows users to select and manage different prompt types for generating test cases using OpenAI.

- Updated `GenerateAndExportTests` in `QaseCommands.cs` to use `UserSettings.PromptSettings.Notes` instead of `OpenAISettings.Notes`.
- Added `SelectPrompt` method in `SettingsCommands.cs` for selecting prompt types.
- Updated `ChangeQaseSettings` in `SettingsCommands.cs` to include prompt type changes.
- Updated `ShowPromptTemplates` in `ShowCommands.cs` to use `PromptType` and display the prompt template.
- Added `ShowCurrentPrompt` method in `ShowCommands.cs` to display the current prompt.
- Updated `UserSettingsDto` to include `PromptSettings`.
- Added new commands in `AppSettings.cs` for changing and showing the selected prompt.
- Refactored `OpenAISettings.cs` to use `PromptSettings` class for managing prompt types.
- Updated `UserSettings.cs` to include `PromptSettings`.
- Added `PromptSettings` class in `PromptSettings.cs` for encapsulating prompt-related properties and methods.
- Added `PromptType` enum in `PromptType.cs` to define possible prompt types (Default, Trade, AMS, AT).